### PR TITLE
Add first version of autodiscovery working with circus-web

### DIFF
--- a/circusweb/templates/connect.html
+++ b/circusweb/templates/connect.html
@@ -5,6 +5,15 @@
 <p id="countdown">Autoconnect in <strong id="countdown-value"></strong>s</p>
 <form id='connector' action="${url('connect')}" method="POST">
 <input id="endpoint" type="text" name="endpoint" value="tcp://127.0.0.1:5555"/>
+% if endpoints:
+    <p>OR</p>
+    <select name="endpoint_select">
+    <option value="">-----</option>
+    % for endpoint in endpoints:
+        <option value="${endpoint}">${endpoint}</option>
+    % endfor
+    </select>
+% endif
 <input type="submit" class="connect" value="Connect"/>
 </form>
 
@@ -32,5 +41,5 @@
         }
     }
   }, 1000);
-  
+
 </script>

--- a/circusweb/tests/test_utils.py
+++ b/circusweb/tests/test_utils.py
@@ -1,0 +1,57 @@
+import sys
+from time import time
+from gevent import sleep
+
+from circusweb.util import AutoDiscoveryThread
+
+from circus.tests.support import TestCircus
+from circus.util import DEFAULT_ENDPOINT_MULTICAST, DEFAULT_ENDPOINT_DEALER
+
+
+class TestAutoDiscovery(TestCircus):
+    def setUp(self):
+        TestCircus.setUp(self)
+
+    def test_auto_discovery(self):
+        self._stop_runners()
+
+        dummy_process = 'circus.tests.support.run_process'
+        self._run_circus(dummy_process)
+
+        thread = AutoDiscoveryThread(DEFAULT_ENDPOINT_MULTICAST)
+        thread.daemon = True
+        thread.start()
+
+        def oracle():
+            self.assertIn(DEFAULT_ENDPOINT_DEALER, thread.get_endpoints())
+        retry_timeout(oracle, 10)
+
+
+def retry_timeout(oracle, timeout=5, step=0.1):
+    """ For a given oracle, a callable, try to execute it.
+
+    If it doesn't raises an AssertionError, oracle is green, return and
+    continue execution.
+    Else, if we doesn't reach the timeout, sleep for step seconds and try
+    again.
+    If we reach the timeout, raise an AssertionError.
+    """
+
+    assert timeout > 0, "Timeout should be > 0"
+
+    begin_time = time()
+
+    etype = value = traceback = None
+    while (time() - begin_time) < timeout:
+        try:
+            oracle()
+            break
+        except AssertionError:
+            etype, value, traceback = sys.exc_info()
+        sleep(step)
+    else:
+        if not value or not etype or not traceback:
+            raise AssertionError('Oracle has not been executed')
+
+        value = "%s\n\nOracle failed during %s seconds." % (value, timeout)
+        raise etype, value, traceback

--- a/circusweb/tests/test_web.py
+++ b/circusweb/tests/test_web.py
@@ -7,8 +7,9 @@ import re
 from webtest import TestApp
 import gevent
 
-from circusweb.circushttpd import app
+from circusweb.circushttpd import app, setup_auto_discovery
 from circus.tests.support import TestCircus
+from circus.util import DEFAULT_ENDPOINT_MULTICAST
 from circus.stream import QueueStream
 
 
@@ -25,6 +26,8 @@ class TestHttpd(TestCircus):
                "from circus import circusd; circusd.main()", cfg]
         self.p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
+        # Start auto discovery thread
+        setup_auto_discovery(DEFAULT_ENDPOINT_MULTICAST)
 
     def tearDown(self):
         self.p.terminate()


### PR DESCRIPTION
Enable autodiscovery on circushttpd.
For now the httpd server has to be started after all the circusd daemons but it will be fixed on the circusd daemon in a next PR

Refs mozilla-services/circus#112
