### PR TITLE
Use url builder instead of hardcoded urls

### DIFF
--- a/circusweb/templates/base.html
+++ b/circusweb/templates/base.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<% from bottle import url %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -12,15 +13,15 @@
     <!--[if IE]>
         <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link rel="stylesheet" href="/media/circus.css" type="text/css" />
-    <link rel="shortcut icon" href="/media/favicon.ico"/>
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
-    <script type="text/javascript" src="/media/socket.io.js"></script>
-    <script type="text/javascript" src="/media/jquery.min.js"></script>
+    <link rel="stylesheet" href="${url('media', filename='circus.css')}" type="text/css" />
+    <link rel="shortcut icon" href="${url('media', filename='favicon.ico')}"/>
+    <link rel="shortcut icon" type="image/x-icon" href="${url('media', filename='favicon.ico')}" />
+    <script type="text/javascript" src="${url('media', filename='socket.io.js')}"></script>
+    <script type="text/javascript" src="${url('media', filename='jquery.min.js')}"></script>
     
-    <script type="text/javascript" src="/media/rickshaw.min.js"></script>
-    <script type="text/javascript" src="/media/d3.v2.js"></script>
-    <script type="text/javascript" src="/media/circus.js"></script>
+    <script type="text/javascript" src="${url('media', filename='rickshaw.min.js')}"></script>
+    <script type="text/javascript" src="${url('media', filename='d3.v2.js')}"></script>
+    <script type="text/javascript" src="${url('media', filename='circus.js')}"></script>
 </head>
 <body>
     % if client:
@@ -64,9 +65,9 @@
     </div>
     % endif
     <header>
-        <img id="logo" src="/media/circus.png" border="0" />
+        <img id="logo" src="${url('media', filename='circus.png')}" border="0" />
         % if client:
-            <a href="/disconnect" class="disconnect">Logout</a>
+            <a href="${url('disconnect')}" class="disconnect">Logout</a>
         % endif
     </header>
     <section id="wrapper">
@@ -75,10 +76,10 @@
               <a href="#" class="add_watcher">Add Watcher</a>
               <nav>
                 <ul>
-                  <li><a href="/">Home</a></li>
-                  <li><a href="/#overview">Overview</a></li>
-                  <li><a href="/#options">Options</a></li>
-                  <li><a href="#">Help</a></li>
+                  <li><a href="${url('index')}">Home</a></li>
+                  <li><a href="${url('index')}#overview">Overview</a></li>
+                  <li><a href="${url('index')}#options">Options</a></li>
+                  <li><a href="${url('index')}#">Help</a></li>
                 </ul>
               </nav>
             </aside>

--- a/circusweb/templates/connect.html
+++ b/circusweb/templates/connect.html
@@ -1,8 +1,9 @@
 <%inherit file="base.html"/>
+<% from bottle import url %>
 
 <h1>Connect to a Circus system</h1>
 <p id="countdown">Autoconnect in <strong id="countdown-value"></strong>s</p>
-<form id='connector' action="/connect" method="POST">
+<form id='connector' action="${url('connect')}" method="POST">
 <input id="endpoint" type="text" name="endpoint" value="tcp://127.0.0.1:5555"/>
 <input type="submit" class="connect" value="Connect"/>
 </form>

--- a/circusweb/templates/index.html
+++ b/circusweb/templates/index.html
@@ -1,5 +1,5 @@
 <%inherit file="base.html"/>
-
+<% from bottle import url %>
 <% goptions = dict(client.get_global_options()) %>
 
 <div class="title">
@@ -24,13 +24,13 @@
 % for watcher, options in client.watchers:
     % if watcher not in client.plugins:
     <div class="watcher">
-        <div style="width: 300px;"><a class="link" href="/watchers/${watcher}">${watcher}</a></div>
+        <div style="width: 300px;"><a class="link" href="${url('watcher', name=watcher)}">${watcher}</a></div>
         <div style="width: 80px;">${options['numprocesses']}</div>
         <div style="width: 342px;">${options['cmd']} ${options['args']}</div>
         <div style="width: 50px;">${options['shell']}</div>
         <div style="width: 50px;">${options['uid']}</div>
         <div style="width: 50px;">${options['gid']}</div>
-        <div style="width: 50px;"><a class="${client.get_status(watcher)}" title="${client.get_status(watcher)}" href="/watchers/${watcher}/switch_status"></a></div>
+        <div style="width: 50px;"><a class="${client.get_status(watcher)}" title="${client.get_status(watcher)}" href="${url('switch_status', name=watcher)}"></a></div>
     </div>
     %endif
 %endfor
@@ -66,7 +66,7 @@
 	<span class="age-stat" id="${watcher}_last_age"></span>
 
         %if display_status:
-        <div style="width: 20px; float: right; margin-right: 10px;"><a class="${client.get_status(watcher)}" title="${client.get_status(watcher)}" href="/watchers/${watcher}/switch_status"></a></div>
+        <div style="width: 20px; float: right; margin-right: 10px;"><a class="${client.get_status(watcher)}" title="${client.get_status(watcher)}" href="${url('switch_status', name=watcher)}"></a></div>
         %endif
     </div>
 
@@ -99,7 +99,7 @@
  %endif
 
  %if client.use_sockets:
- ${draw_graph_div('socket-stats', 'Socket Activity (<a href="/sockets">see all the sockets</a>)', socket=True)}
+ ${draw_graph_div('socket-stats', 'Socket Activity (<a href="' + url('sockets') + '">see all the sockets</a>)', socket=True)}
  %endif
 
  %for plugin in client.plugins:

--- a/circusweb/templates/sockets.html
+++ b/circusweb/templates/sockets.html
@@ -1,4 +1,5 @@
 <%inherit file="base.html"/>
+<% from bottle import url %>
 
 % if client:
     <div class="title">
@@ -30,7 +31,7 @@
     </div>
     %endfor
 
-<script src="/media/socket.io.js"></script>
+<script src="${url('media', filename='socket.io.js')}"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         var socket = io.connect('${SERVER}');

--- a/circusweb/templates/watcher.html
+++ b/circusweb/templates/watcher.html
@@ -1,10 +1,11 @@
 <%inherit file="base.html"/>
+<% from bottle import url %>
 
 % if client:
     <div class="title">
      <div class="watcher_name">Watcher <strong>${name}</strong>
       <a style="display:inline-block;" class="${client.get_status(name)}"
-         title="${client.get_status(name)}" href="/watchers/${name}/switch_status?redirect=/watchers/${name}"></a></div>
+         title="${client.get_status(name)}" href="${url('switch_status', name=name)}?redirect=${url('watcher', name=name)}"></a></div>
       <div class="watcher_description"><strong>${client.get_option(name, 'numprocesses')}</strong> <span>processes</span>
      </div>
     </div>
@@ -27,8 +28,8 @@
             <span style="display: inline-block; float: left;" class="label">Process #${pid}</span><span id="${name}-${pid}_last_age" class="age-stat"></span>
 
             <span style="display: inline-block; float: right;">
-                <a href="/watchers/${name}/process/kill/${pid}" title="Kill">
-                    <img src="/media/kill.png" border="0" alt="Kill" />
+                <a href="${url('kill_process', name=name, pid=pid)}" title="Kill">
+                    <img src="${url('media', filename='kill.png')}" border="0" alt="Kill" />
                 </a>
             </span>
         </div>
@@ -52,7 +53,7 @@
             <span class="label">Add process</span>
         </div>
         <div class="stat">
-             <a class="add_process" title="Add process" href="/watchers/${name}/process/incr?redirect=/watchers/${name}">+</a>
+             <a class="add_process" title="Add process" href="${url('incr_proc', name=name)}?redirect=${url('watcher', name=name)}">+</a>
         </div>
     </div>
     %endif
@@ -130,9 +131,9 @@
             Number of processes
             </td>
             <td class="value">
-                <a href="/watchers/${name}/process/incr?redirect=/watchers/${name}"><span class="orangelabel">+</span></a>
+                <a href="${url('incr_proc', name=name)}?redirect=${url('watcher', name=name)}"><span class="orangelabel">+</span></a>
                 <span class="num_process">${options['numprocesses']}</span>
-                <a href="/watchers/${name}/process/decr?redirect=/watchers/${name}"><span class="orangelabel">-</span></a>
+                <a href="${url('decr_proc', name=name)}?redirect=${url('watcher', name=name)}"><span class="orangelabel">-</span></a>
             </td>
         </tr>
         <tr>
@@ -153,7 +154,7 @@
         </tr>
     </table>
 
-<script src="/media/socket.io.js"></script>
+<script src="${url('media', filename='socket.io.js')}"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         var socket = io.connect('${SERVER}');


### PR DESCRIPTION
Hello,

First of all I would like to give big thanks for everyone who was involved in this good project.

We've failed to setup circus-web project in not-rooted dir behind proxy using following configuration:

http://localhost:80/circus/, Nginx as proxy (note **circus** virtual dir here)
http://localhost:8080/, circushttpd as upstream web server

In order to solve this issue I did a switch from hardcoded urls and str.format urls into url builder provided by bottle framework.

Please consider accept those changes. Hoping that they could be useful for someone else.

I'm going to carefully test everything during this/next week, so current pull request does not have rock solid quality.

I just want to share my intentions with you.

Thank you in advance.
