### PR TITLE
Re-implement circusweb with tornadoweb

### DIFF
--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -1,11 +1,25 @@
 import argparse
 import os
+import os.path
 import sys
+import json
+from base64 import b64encode, b64decode
+from zmq.eventloop import ioloop
 
 try:
-    from beaker.middleware import SessionMiddleware
-    from bottle import app, run, url, static_file, redirect, request
-    from socketio import socketio_manage
+    import tornado.httpserver
+    import tornado.ioloop
+    import tornado.web
+
+    from tornado import gen
+    from tornado.escape import json_decode, json_encode
+    from tornado.options import define, options
+    from tornado.web import URLSpec
+
+    import tornadio2
+
+    from mako import exceptions
+    from tomako import MakoTemplateLoader
 except ImportError, e:
     reqs = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                         'web-requirements.txt')
@@ -13,13 +27,22 @@ except ImportError, e:
                       'You can do so by using "pip install -r '
                       '%s"\nInitial error: %s' % (reqs, str(e)))
 
-from circusweb.namespace import StatsNamespace
-from circusweb import __version__, logger
+
+from circus.exc import CallError
 from circus.util import configure_logger, LOG_LEVELS
-from circusweb.util import (run_command, render_template, set_message, route,
-                            MEDIADIR, AutoDiscoveryThread)
-from circusweb.session import connect_to_circus, disconnect_from_circus
-from circusweb.server import SocketIOServer
+
+from circusweb.namespace import SocketIOConnection
+from circusweb import __version__, logger
+from circusweb.util import (run_command, AutoDiscovery)
+from circusweb.session import (
+    connect_to_circus, disconnect_from_circus, get_controller)
+
+from functools import wraps
+
+
+CURDIR = os.path.dirname(__file__)
+TMPLDIR = os.path.join(CURDIR, 'templates')
+STATIC_PATH = os.path.join(CURDIR, 'media')
 
 
 session_opts = {
@@ -30,123 +53,282 @@ session_opts = {
 }
 
 
-app = SessionMiddleware(app(), session_opts)
+def require_logged_user(func):
+
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+
+        user = self.get_current_user()
+        controller = get_controller()
+
+        if not user or not controller:
+            self.clean_user_session()
+            return self.redirect(self.application.reverse_url('connect'))
+
+        return func(self, *args, **kwargs)
+
+    return wrapped
 
 
-@route('/media/<filename:path>', name='media', ensure_client=False)
-def get_media(filename):
-    return static_file(filename, root=MEDIADIR)
+class BaseHandler(tornado.web.RequestHandler):
+
+    def render_template(self, template_path, **data):
+        namespace = self.get_template_namespace()
+        user = self.get_current_user()
+        server = '%s://%s/' % (self.request.protocol, self.request.host)
+        namespace.update({'controller': get_controller(),
+                          'version': __version__,
+                          'b64encode': b64encode,
+                          'dumps': json.dumps,
+                          'user': user, 'SERVER': server})
+
+        # Stats endpoints
+        controller = get_controller()
+        if user and controller:
+            endpoints = user['endpoints']
+            stats_endpoints = []
+            for endpoint in endpoints:
+                client = controller.get_client(endpoint)
+                if client and client.stats_endpoint:
+                    stats_endpoints.append(client.stats_endpoint)
+            namespace.update({'stats_endpoints': stats_endpoints,
+                              'endpoints': user['endpoints']})
+
+        namespace.update(data)
+
+        try:
+            template = app.loader.load(template_path)
+            return template.generate(**namespace)
+        except Exception:
+            print exceptions.text_error_template().render()
+
+    def get_current_user(self):
+        user = self.get_secure_cookie("user")
+        if not user:
+            return None
+        else:
+            return json_decode(user)
+
+    def clean_user_session(self):
+        """Disconnect the endpoint the user was logged on + Remove cookies."""
+        user = self.get_current_user()
+        if user:
+            user = user
+            endpoints = user['endpoints']
+            for endpoint in endpoints:
+                disconnect_from_circus(endpoint)
+        self.clear_all_cookies()
 
 
-@route('/', method='GET', name='index')
-def index():
-    return render_template('index.html')
+class IndexHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self):
+        controller = get_controller()
+        user = self.get_current_user()
+        endpoints = user['endpoints']
+        goptions = yield gen.Task(controller.get_global_options, endpoints[0])
+        self.finish(self.render_template('index.html', goptions=goptions))
 
 
-@route('/watchers/<name>/process/kill/<pid>', name='kill_process')
-def kill_process(name, pid):
-    return run_command(
-        func='killproc', args=(name, pid),
-        message='process {pid} killed sucessfully'.format(pid=pid),
-        redirect_url=url('watcher', name=name))
+class ConnectHandler(BaseHandler):
 
+    def show_form(self):
+        self.finish(
+            self.render_template('connect.html',
+                                 endpoints=app.auto_discovery.get_endpoints()))
 
-@route('/watchers/<name>/process/decr', method='GET', name='decr_proc')
-def decr_proc(name):
-    return run_command(
-        func='decrproc', args=(name,),
-        message='removed one process from the {watcher} pool'.format(
-            watcher=name),
-        redirect_url=url('watcher', name=name))
+    def get(self):
+        self.show_form()
 
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def post(self):
+        endpoint = self.get_argument('endpoint', None)
 
-@route('/watchers/<name>/process/incr', method='GET', name='incr_proc')
-def incr_proc(name):
+        if not endpoint:
+            self.finish(self.show_form())
 
-    return run_command(
-        func='incrproc', args=(name,),
-        message='added one process to the {watcher} pool'.format(watcher=name),
-        redirect_url=url('watcher', name=name))
-
-
-@route('/watchers/<name>/switch_status', method='GET', name='switch_status')
-def switch(name):
-    return run_command(func='switch_status', args=(name,),
-                       message='status switched', redirect_url=url('index'))
-
-
-@route('/add_watcher', method='POST')
-def add_watcher():
-    return run_command('add_watcher',
-                       kwargs=request.POST,
-                       message='added a new watcher',
-                       redirect_url=url('watcher', name=request.POST),
-                       redirect_on_error=url('index'))
-
-
-@route('/watchers/<name>', method='GET', name='watcher')
-def watcher(name):
-    return render_template('watcher.html', name=name)
-
-
-@route('/sockets', method='GET', name='sockets')
-def sockets():
-    return render_template('sockets.html')
-
-
-# XXX we need to add the ssh server option in the form
-@route('/connect', method=['POST', 'GET'], name='connect', ensure_client=False)
-def connect():
-    """Connects to the stats client, using the endpoint that's passed in the
-    POST body.
-    """
-    def _ask_connection():
-        return render_template('connect.html',
-                               endpoints=app.discovery_thread.get_endpoints())
-
-    if request.method == 'GET':
-        return _ask_connection()
-
-    elif request.method == 'POST':
-        # if we got an endpoint in the POST body, store it.
-        if request.forms.endpoint is None:
-            return _ask_connection()
-
-        endpoint_input = request.forms.endpoint
-        endpoint_select = request.forms.endpoint_select
-
+        endpoint_select = self.get_argument('endpoint_select', None)
         if endpoint_select:
             endpoint = endpoint_select
+
+        try:
+            yield gen.Task(connect_to_circus, tornado.ioloop.IOLoop.instance(),
+                           endpoint)
+        except CallError:
+            # TODO SHOW MESSAGE
+            self.redirect(self.reverse_url('connect'))
         else:
-            endpoint = endpoint_input
-
-        client = connect_to_circus(endpoint)
-        if not client.connected:
-            set_message('Impossible to connect')
-
-        redirect(url('index'))
+            self.set_secure_cookie("user",
+                                   json_encode({'endpoints': [endpoint]}))
+            self.redirect(self.reverse_url('index'))
 
 
-@route('/disconnect', name='disconnect')
-def disconnect():
-    if disconnect_from_circus():
-        set_message('You are now disconnected')
-    redirect(url('index'))
+class DisconnectHandler(BaseHandler):
+
+    @require_logged_user
+    def get(self):
+        self.clean_user_session()
+        self.redirect(self.reverse_url('index'))
 
 
-@route('/socket.io/<someid>/websocket/<socket_id>', method='GET')
-def socketio(someid, socket_id):
-    return socketio_manage(request.environ, {'': StatsNamespace})
+class WatcherAddHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def post(self, endpoint):
+        url = yield gen.Task(
+            run_command, 'add_watcher',
+            kwargs=dict((k, v[0]) for k, v in
+                        self.request.arguments.iteritems()),
+            message='added a new watcher', endpoint=b64decode(endpoint),
+            redirect_url=self.reverse_url('watcher',
+                                          self.get_argument('name').lower()),
+            redirect_on_error=self.reverse_url('index'))
+        self.redirect(url)
+
+
+class WatcherHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self, name):
+        controller = get_controller()
+        user = self.get_current_user()
+        endpoints = user['endpoints']
+        pids = yield gen.Task(controller.get_pids, name, endpoints)
+        self.finish(self.render_template('watcher.html', pids=pids, name=name))
+
+
+class WatcherSwitchStatusHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self, endpoint, name):
+        url = yield gen.Task(run_command, command='switch_status',
+                             message='status switched',
+                             endpoint=b64decode(endpoint),
+                             args=(name,),
+                             redirect_url=self.reverse_url('index'))
+        self.redirect(url)
+
+
+class KillProcessHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self, endpoint, name, pid):
+        msg = 'process {pid} killed sucessfully'
+        url = yield gen.Task(run_command, command='killproc',
+                             message=msg.format(
+                                 pid=pid),
+                             endpoint=b64decode(endpoint),
+                             args=(name, pid),
+                             redirect_url=self.reverse_url('watcher', name))
+        self.redirect(url)
+
+
+class DecrProcHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self, endpoint, name):
+        msg = 'removed one process from the {watcher} pool'
+        url = yield gen.Task(run_command, command='decrproc',
+                             message=msg.format(watcher=name),
+                             endpoint=b64decode(endpoint),
+                             args=(name,),
+                             redirect_url=self.reverse_url('watcher', name))
+        self.redirect(url)
+
+
+class IncrProcHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self, endpoint, name):
+        msg = 'added one process to the {watcher} pool'
+        url = yield gen.Task(run_command, command='incrproc',
+                             message=msg.format(watcher=name),
+                             endpoint=b64decode(endpoint),
+                             args=(name,),
+                             redirect_url=self.reverse_url('watcher', name))
+        self.redirect(url)
+
+
+class SocketsHandler(BaseHandler):
+
+    @require_logged_user
+    @tornado.web.asynchronous
+    @gen.coroutine
+    def get(self):
+        user = self.get_current_user()
+        controller = get_controller()
+        endpoints = user['endpoints']
+        sockets = yield gen.Task(controller.get_sockets, endpoint=endpoints[0])
+        self.finish(
+            self.render_template('sockets.html', sockets=sockets))
+
+
+class Application(tornado.web.Application):
+
+    def __init__(self):
+        handlers = [
+            URLSpec(r'/',
+                    IndexHandler, name="index"),
+            URLSpec(r'/connect/',
+                    ConnectHandler, name="connect"),
+            URLSpec(r'/disconnect/',
+                    DisconnectHandler, name="disconnect"),
+            URLSpec(r'/watcher/([^/]+)/',
+                    WatcherHandler, name="watcher"),
+            URLSpec(r'/([^/]+)/add_watcher/',
+                    WatcherAddHandler, name="add_watcher"),
+            URLSpec(r'/([^/]+)/watcher/([^/]+)/switch_status/',
+                    WatcherSwitchStatusHandler, name="switch_status"),
+            URLSpec(r'/([^/]+)/watcher/([^/]+)/process/kill/([^/]+)/',
+                    KillProcessHandler, name="kill_process"),
+            URLSpec(r'/([^/]+)/watcher/([^/]+)/process/decr/',
+                    DecrProcHandler, name="decr_proc"),
+            URLSpec(r'/([^/]+)/watcher/([^/]+)/process/incr/',
+                    IncrProcHandler, name="incr_proc"),
+            URLSpec(r'/sockets/',
+                    SocketsHandler, name="sockets"),
+        ]
+
+        self.loader = MakoTemplateLoader(TMPLDIR)
+        self.router = tornadio2.TornadioRouter(SocketIOConnection)
+        handlers += self.router.urls
+
+        settings = {
+            'template_loader': self.loader,
+            'static_path': STATIC_PATH,
+            'debug': True,
+            'cookie_secret': 'fxCIK+cbRZe6zhwX8yIQDVS54LFfB0I+nQt0pGp3IY0='
+        }
+
+        tornado.web.Application.__init__(self, handlers, **settings)
+
+
+app = Application()
 
 
 def main():
+    define("port", default=8080, type=int)
     parser = argparse.ArgumentParser(description='Run the Web Console')
 
     parser.add_argument('--fd', help='FD', default=None)
     parser.add_argument('--host', help='Host', default='0.0.0.0')
     parser.add_argument('--port', help='port', default=8080)
-    parser.add_argument('--server', help='web server to use',
-                        default=SocketIOServer)
     parser.add_argument('--endpoint', default=None,
                         help='Circus Endpoint. If not specified, Circus will '
                              'ask you which system you want to connect to')
@@ -176,21 +358,20 @@ def main():
     if args.endpoint is not None:
         connect_to_circus(args.endpoint, args.ssh)
 
-    try:
-        sys.stderr.write(' ')
-        quiet = False
-    except IOError:
-        quiet = True
+    options.parse_command_line()
 
-    setup_auto_discovery(args.multicast)
-    run(app, host=args.host, port=args.port, server=args.server,
-        fd=args.fd, quiet=quiet)
+    # Install zmq.eventloop to replace tornado.ioloop
+    ioloop.install()
 
+    # Get the tornado ioloop singleton
+    loop = tornado.ioloop.IOLoop.instance()
 
-def setup_auto_discovery(multicast_endpoint):
-    app.discovery_thread = AutoDiscoveryThread(multicast_endpoint)
-    app.discovery_thread.daemon = True
-    app.discovery_thread.start()
+    app.auto_discovery = AutoDiscovery(args.multicast, loop)
+
+    http_server = tornado.httpserver.HTTPServer(app)
+    http_server.listen(options.port, "0.0.0.0")
+    logger.info("Starting circus web ui on port %s" % (options.port))
+    loop.start()
 
 
 if __name__ == '__main__':

--- a/circusweb/client.py
+++ b/circusweb/client.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -
+import uuid
+
+import zmq
+from zmq.utils.jsonapi import jsonmod as json
+from zmq.eventloop.zmqstream import ZMQStream
+
+from circus.exc import CallError
+from circus.py3compat import string_types
+from circus.util import get_connection
+from circus.client import CircusClient, make_message
+
+from collections import defaultdict
+
+from datetime import timedelta
+
+from tornado import gen
+
+
+class AsynchronousCircusClient(CircusClient):
+    """
+    An asynchronous circus client implementation designed to works with tornado
+    IOLoop
+    """
+    def __init__(self, loop, endpoint, context=None, timeout=5.0,
+                 ssh_server=None, ssh_keyfile=None):
+        self.context = context or zmq.Context.instance()
+        self.ssh_server = ssh_server
+        self.ssh_keyfile = ssh_keyfile
+        self._timeout = timeout
+        self.timeout = timeout * 1000
+        self.loop = loop
+        self.endpoint = endpoint
+
+        # Infos
+        self.stats_endpoint = None
+        self.connected = False
+        self.watchers = []
+        self.plugins = []
+        self.stats = defaultdict(list)
+        self.dstats = []
+        self.sockets = None
+        self.use_sockets = False
+        self.embed_httpd = False
+
+        # Connection counter
+        self.count = 0
+
+    def send_message(self, command, callback=None, **props):
+        return self.call(make_message(command, **props), callback)
+
+    def call(self, cmd, callback):
+        if not isinstance(cmd, string_types):
+            try:
+                cmd = json.dumps(cmd)
+            except ValueError as e:
+                raise CallError(str(e))
+
+        socket = self.context.socket(zmq.DEALER)
+        socket.setsockopt(zmq.IDENTITY, uuid.uuid4().hex)
+        socket.setsockopt(zmq.LINGER, 0)
+        get_connection(socket, self.endpoint, self.ssh_server,
+                       self.ssh_keyfile)
+
+        if callback:
+            stream = ZMQStream(socket, self.loop)
+
+            def timeout_callback():
+                stream.stop_on_recv()
+                stream.close()
+                raise CallError('Call timeout for cmd', cmd)
+
+            timeout = self.loop.add_timeout(timedelta(seconds=5),
+                                            timeout_callback)
+
+            def recv_callback(msg):
+                self.loop.remove_timeout(timeout)
+                stream.stop_on_recv()
+                stream.close()
+                callback(json.loads(msg[0]))
+
+            stream.on_recv(recv_callback)
+
+        try:
+            socket.send(cmd)
+        except zmq.ZMQError, e:
+            raise CallError(str(e))
+
+        if not callback:
+            return json.loads(socket.recv())
+
+    @gen.coroutine
+    def update_watchers(self):
+        """Calls circus and initialize the list of watchers.
+
+        If circus is not connected raises an error.
+        """
+        self.watchers = []
+        self.plugins = []
+
+        # trying to list the watchers
+        try:
+            self.connected = True
+            watchers = yield gen.Task(self.send_message, 'list')
+            watchers = watchers['watchers']
+
+            for watcher in watchers:
+                if watcher in ('circusd-stats', 'circushttpd'):
+                    if watcher == 'circushttpd':
+                        self.embed_httpd = True
+                    continue
+
+                options = yield gen.Task(self.send_message, 'options',
+                                         name=watcher)
+                options = options['options']
+
+                self.watchers.append((watcher, options))
+                if watcher.startswith('plugin:'):
+                    self.plugins.append(watcher)
+
+                if not self.use_sockets and options.get('use_sockets', False):
+                    self.use_sockets = True
+
+            self.watchers.sort()
+            global_options = yield gen.Task(self.get_global_options)
+            self.stats_endpoint = global_options['stats_endpoint']
+            if self.endpoint.startswith('tcp://'):
+                # In case of multi interface binding i.e: tcp://0.0.0.0:5557
+                anyaddr = '0.0.0.0'
+                ip = self.endpoint.lstrip('tcp://').split(':')[0]
+                self.stats_endpoint = self.stats_endpoint.replace(anyaddr, ip)
+        except CallError:
+            self.connected = False
+
+    @gen.coroutine
+    def get_global_options(self):
+        res = yield gen.Task(self.send_message, 'globaloptions')
+        raise gen.Return(res['options'])

--- a/circusweb/media/circus.js
+++ b/circusweb/media/circus.js
@@ -57,7 +57,7 @@ function hookGraph(socket, watcher, metrics, prefix, capValues, config) {
 }
 
 
-function supervise(socket, watchers, watchersWithPids, config) {
+function supervise(socket, watchers, watchersWithPids, endpoints, stats_endpoints, config) {
 
     if (watchersWithPids == undefined) { watchersWithPids = []; }
     if (config == undefined) { config = DEFAULT_CONFIG; }
@@ -91,9 +91,15 @@ function supervise(socket, watchers, watchersWithPids, config) {
         }
     });
 
+    console.log({ watchers: watchers,
+                               watchersWithPids: watchersWithPids,
+                               stats_endpoints: stats_endpoints});
+
     // start the streaming of data, once the callbacks in place.
     socket.emit('get_stats', { watchers: watchers,
-                               watchersWithPids: watchersWithPids});
+                               watchersWithPids: watchersWithPids,
+                               endpoints: endpoints,
+                               stats_endpoints: stats_endpoints});
 }
 
 $(document).ready(function() {

--- a/circusweb/server.py
+++ b/circusweb/server.py
@@ -1,8 +1,7 @@
 import socket
-from bottle import ServerAdapter
 
 
-class SocketIOServer(ServerAdapter):
+class SocketIOServer(object):
     def __init__(self, host='127.0.0.1', port=8080, **config):
         super(SocketIOServer, self).__init__(host, port, **config)
         self.fd = config.get('fd')
@@ -14,9 +13,6 @@ class SocketIOServer(ServerAdapter):
             from socketio.server import SocketIOServer
         except ImportError:
             raise ImportError('You need to install gevent_socketio')
-
-        # sets up the ZMQ/Gevent environ
-        from circus import _patch   # NOQA
 
         namespace = self.options.get('namespace', 'socket.io')
         policy_server = self.options.get('policy_server', False)

--- a/circusweb/stats_client.py
+++ b/circusweb/stats_client.py
@@ -1,0 +1,57 @@
+import errno
+import json
+import zmq
+
+from zmq.eventloop.zmqstream import ZMQStream
+
+from circus.util import DEFAULT_ENDPOINT_SUB, get_connection
+
+
+class AsynchronousStatsConsumer(object):
+    def __init__(self, topics, loop, callback, context=None,
+                 endpoint=DEFAULT_ENDPOINT_SUB, ssh_server=None, timeout=1.):
+        self.topics = topics
+        self.keep_context = context is not None
+        self.context = context or zmq.Context()
+        self.endpoint = endpoint
+        self.pubsub_socket = self.context.socket(zmq.SUB)
+        get_connection(self.pubsub_socket, self.endpoint, ssh_server)
+        for topic in self.topics:
+            self.pubsub_socket.setsockopt(zmq.SUBSCRIBE, topic)
+        self.stream = ZMQStream(self.pubsub_socket, loop)
+        self.stream.on_recv(self.process_message)
+        self.callback = callback
+        self.timeout = timeout
+
+        # Connection counter
+        self.count = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """ On context manager exit, destroy the zmq context """
+        self.stop()
+
+    def process_message(self, msg):
+        topic, stat = msg
+
+        topic = topic.split('.')
+        if len(topic) == 3:
+            __, watcher, subtopic = topic
+            self.callback(watcher, subtopic, json.loads(stat), self.endpoint)
+        elif len(topic) == 2:
+            __, watcher = topic
+            self.callback(watcher, None, json.loads(stat), self.endpoint)
+
+    def stop(self):
+        self.stream.stop_on_recv()
+        if self.keep_context:
+            return
+        try:
+            self.context.destroy(0)
+        except zmq.ZMQError as e:
+            if e.errno == errno.EINTR:
+                pass
+            else:
+                raise

--- a/circusweb/templates/base.html
+++ b/circusweb/templates/base.html
@@ -1,5 +1,4 @@
 <!doctype html>
-<% from bottle import url %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -13,24 +12,24 @@
     <!--[if IE]>
         <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link rel="stylesheet" href="${url('media', filename='circus.css')}" type="text/css" />
-    <link rel="shortcut icon" href="${url('media', filename='favicon.ico')}"/>
-    <link rel="shortcut icon" type="image/x-icon" href="${url('media', filename='favicon.ico')}" />
-    <script type="text/javascript" src="${url('media', filename='socket.io.js')}"></script>
-    <script type="text/javascript" src="${url('media', filename='jquery.min.js')}"></script>
-    
-    <script type="text/javascript" src="${url('media', filename='rickshaw.min.js')}"></script>
-    <script type="text/javascript" src="${url('media', filename='d3.v2.js')}"></script>
-    <script type="text/javascript" src="${url('media', filename='circus.js')}"></script>
+    <link rel="stylesheet" href="${static_url('circus.css')}" type="text/css" />
+    <link rel="shortcut icon" href="${static_url('favicon.ico')}"/>
+    <link rel="shortcut icon" type="image/x-icon" href="${static_url('favicon.ico')}" />
+    <script type="text/javascript" src="${static_url('socket.io.js')}"></script>
+    <script type="text/javascript" src="${static_url('jquery.min.js')}"></script>
+
+    <script type="text/javascript" src="${static_url('rickshaw.min.js')}"></script>
+    <script type="text/javascript" src="${static_url('d3.v2.js')}"></script>
+    <script type="text/javascript" src="${static_url('circus.js')}"></script>
 </head>
 <body>
-    % if client:
+    % if user:
     <div id="overlay" style="display:none;">
         <div class="overlay">
             <div class="dialog-header">
                 <h3>Add Watcher</h3>
             </div>
-            <form action="add_watcher" method="POST">
+            <form action="${reverse_url('add_watcher', b64encode(endpoints[0]))}" method="POST">
 
                 <p>
                     <label for="name">Name</label>
@@ -65,21 +64,21 @@
     </div>
     % endif
     <header>
-        <img id="logo" src="${url('media', filename='circus.png')}" border="0" />
-        % if client:
-            <a href="${url('disconnect')}" class="disconnect">Logout</a>
+        <a href="/"><img id="logo" src="${static_url('circus.png')}" border="0" /></a>
+        % if user:
+            <a href="${reverse_url('disconnect')}" class="disconnect">Logout</a>
         % endif
     </header>
     <section id="wrapper">
-        % if client:
-            <aside> 
+        % if user:
+            <aside>
               <a href="#" class="add_watcher">Add Watcher</a>
               <nav>
                 <ul>
-                  <li><a href="${url('index')}">Home</a></li>
-                  <li><a href="${url('index')}#overview">Overview</a></li>
-                  <li><a href="${url('index')}#options">Options</a></li>
-                  <li><a href="${url('index')}#">Help</a></li>
+                  <li><a href="${reverse_url('index')}">Home</a></li>
+                  <li><a href="${reverse_url('index')}#overview">Overview</a></li>
+                  <li><a href="${reverse_url('index')}#options">Options</a></li>
+                  <li><a href="${reverse_url('index')}#">Help</a></li>
                 </ul>
               </nav>
             </aside>
@@ -87,16 +86,11 @@
         % else:
             <section id="login">
         % endif
-        % if 'message' in session:
-            <div class="note">
-                ${session.pop('message')}
-            </div>
-        %endif
         ${self.body()}
-        </section>  
+        </section>
     </section>
 
-    <footer> 
+    <footer>
         &copy; Copyright 2012, The Mozilla Foundation - circushttpd v.${version}
     </footer>
 

--- a/circusweb/templates/connect.html
+++ b/circusweb/templates/connect.html
@@ -1,9 +1,8 @@
 <%inherit file="base.html"/>
-<% from bottle import url %>
 
 <h1>Connect to a Circus system</h1>
 <p id="countdown">Autoconnect in <strong id="countdown-value"></strong>s</p>
-<form id='connector' action="${url('connect')}" method="POST">
+<form id='connector' action="${reverse_url('connect')}" method="POST">
 <input id="endpoint" type="text" name="endpoint" value="tcp://127.0.0.1:5555"/>
 % if endpoints:
     <p>OR</p>

--- a/circusweb/templates/index.html
+++ b/circusweb/templates/index.html
@@ -1,6 +1,4 @@
 <%inherit file="base.html"/>
-<% from bottle import url %>
-<% goptions = dict(client.get_global_options()) %>
 
 <div class="title">
     <div style="float: left;" class="watcher_name">Watchers</div>
@@ -21,16 +19,16 @@
         <div style="width: 50px;">gid</div>
         <div style="width: 50px;">Status</div>
     </div>
-% for watcher, options in client.watchers:
-    % if watcher not in client.plugins:
+% for watcher, options in controller.get_client(endpoints[0]).watchers:
+    % if watcher not in controller.get_client(endpoints[0]).plugins:
     <div class="watcher">
-        <div style="width: 300px;"><a class="link" href="${url('watcher', name=watcher)}">${watcher}</a></div>
+        <div style="width: 300px;"><a class="link" href="${reverse_url('watcher', watcher)}">${watcher}</a></div>
         <div style="width: 80px;">${options['numprocesses']}</div>
         <div style="width: 342px;">${options['cmd']} ${options['args']}</div>
         <div style="width: 50px;">${options['shell']}</div>
         <div style="width: 50px;">${options['uid']}</div>
         <div style="width: 50px;">${options['gid']}</div>
-        <div style="width: 50px;"><a class="${client.get_status(watcher)}" title="${client.get_status(watcher)}" href="${url('switch_status', name=watcher)}"></a></div>
+        <div style="width: 50px;"><a class="${controller.get_status(watcher, endpoints[0])}" title="${controller.get_status(watcher, endpoints[0])}" href="${reverse_url('switch_status', b64encode(endpoints[0]), watcher)}"></a></div>
     </div>
     %endif
 %endfor
@@ -49,7 +47,7 @@
         <span class="legend_indicator"></span>
         <span class="">Memory</span>
     </div>
-    %if client.use_sockets:
+    %if controller.get_client(endpoints[0]).use_sockets:
     <div class="legend_reads">
         <span class="legend_indicator"></span>
         <span class="">Socket reads</span>
@@ -66,7 +64,7 @@
 	<span class="age-stat" id="${watcher}_last_age"></span>
 
         %if display_status:
-        <div style="width: 20px; float: right; margin-right: 10px;"><a class="${client.get_status(watcher)}" title="${client.get_status(watcher)}" href="${url('switch_status', name=watcher)}"></a></div>
+        <div style="width: 20px; float: right; margin-right: 10px;"><a class="${controller.get_status(watcher, endpoints[0])}" title="${controller.get_status(watcher, endpoints[0])}" href="${reverse_url('switch_status', name=watcher)}"></a></div>
         %endif
     </div>
 
@@ -94,15 +92,15 @@
  ${draw_graph_div('circus')}
  ${draw_graph_div('circusd-stats')}
 
- %if client.embed_httpd:
+ %if controller.get_client(endpoints[0]).embed_httpd:
  ${draw_graph_div('circushttpd', 'circushttpd')}
  %endif
 
- %if client.use_sockets:
- ${draw_graph_div('socket-stats', 'Socket Activity (<a href="' + url('sockets') + '">see all the sockets</a>)', socket=True)}
+ %if controller.get_client(endpoints[0]).use_sockets:
+ ${draw_graph_div('socket-stats', 'Socket Activity (<a href="' + reverse_url('sockets') + '">see all the sockets</a>)', socket=True)}
  %endif
 
- %for plugin in client.plugins:
+ %for plugin in controller.get_client(endpoints[0]).plugins:
      ${draw_graph_div(plugin, plugin.split(':')[1].replace('-', '.'), True)}
  %endfor
 
@@ -158,20 +156,20 @@ $(document).ready(function () {
     var socket = io.connect('${SERVER}');
     var watchers = ['circusd-stats', 'circus'];
 
-    %if client.use_sockets:
+    %if controller.get_client(endpoints[0]).use_sockets:
         watchers.push('sockets');
     %endif
 
-    %if client.embed_httpd:
+    %if controller.get_client(endpoints[0]).embed_httpd:
         watchers.push('circushttpd');
     %endif
 
 
-    %for plugin in client.plugins:
+    %for plugin in controller.get_client(endpoints[0]).plugins:
         watchers.push('${plugin}');
     %endfor
 
-    supervise(socket, watchers);
+    supervise(socket, watchers, undefined, ${dumps(endpoints)}, ${dumps(stats_endpoints)});
 });
 
 </script>

--- a/circusweb/templates/sockets.html
+++ b/circusweb/templates/sockets.html
@@ -1,7 +1,6 @@
 <%inherit file="base.html"/>
-<% from bottle import url %>
 
-% if client:
+% if controller:
     <div class="title">
      <div class="watcher_name">All sockets activity</div>
     </div>
@@ -14,7 +13,7 @@
     </div>
 
     <div class="box">
-    %for socket in client.get_sockets():
+    %for socket in sockets:
     <div class="process">
       <div>
         %if 'host' in socket:
@@ -37,13 +36,12 @@
     </div>
     %endfor
 
-<script src="${url('media', filename='socket.io.js')}"></script>
+<script src="${static_url('socket.io.js')}"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         var socket = io.connect('${SERVER}');
-        supervise(socket, [], ['sockets']);
+        supervise(socket, [], ['sockets'], ${dumps(endpoints)}, ${dumps(stats_endpoints)});
     });
 </script>
 
 % endif
-

--- a/circusweb/templates/watcher.html
+++ b/circusweb/templates/watcher.html
@@ -1,12 +1,11 @@
 <%inherit file="base.html"/>
-<% from bottle import url %>
 
-% if client:
+% if controller:
     <div class="title">
      <div class="watcher_name">Watcher <strong>${name}</strong>
-      <a style="display:inline-block;" class="${client.get_status(name)}"
-         title="${client.get_status(name)}" href="${url('switch_status', name=name)}?redirect=${url('watcher', name=name)}"></a></div>
-      <div class="watcher_description"><strong>${client.get_option(name, 'numprocesses')}</strong> <span>processes</span>
+      <a style="display:inline-block;" class="${controller.get_status(name, endpoints[0])}"
+         title="${controller.get_status(name, endpoints[0])}" href="${reverse_url('switch_status', b64encode(endpoints[0]), name)}?redirect=${reverse_url('watcher', name)}"></a></div>
+      <div class="watcher_description"><strong>${controller.get_option(name, 'numprocesses', endpoints[0])}</strong> <span>processes</span>
      </div>
     </div>
 
@@ -22,14 +21,14 @@
     </div>
 
     <div class="box">
-    %for pid in client.get_pids(name):
+    %for pid in pids:
     <div class="process">
         <div>
             <span style="display: inline-block; float: left;" class="label">Process #${pid}</span><span id="${name}-${pid}_last_age" class="age-stat"></span>
 
             <span style="display: inline-block; float: right;">
-                <a href="${url('kill_process', name=name, pid=pid)}" title="Kill">
-                    <img src="${url('media', filename='kill.png')}" border="0" alt="Kill" />
+                <a href="${reverse_url('kill_process', b64encode(endpoints[0]), name, pid)}" title="Kill">
+                    <img src="${static_url('kill.png')}" border="0" alt="Kill" />
                 </a>
             </span>
         </div>
@@ -47,13 +46,13 @@
         </div>
     </div>
     %endfor
-    %if not client.get_option(name, 'singleton'):
+    %if not controller.get_option(name, 'singleton', endpoints[0]):
     <div class="process">
         <div>
             <span class="label">Add process</span>
         </div>
         <div class="stat">
-             <a class="add_process" title="Add process" href="${url('incr_proc', name=name)}?redirect=${url('watcher', name=name)}">+</a>
+             <a class="add_process" title="Add process" href="${reverse_url('incr_proc', b64encode(endpoints[0]), name)}?redirect=${reverse_url('watcher', name)}">+</a>
         </div>
     </div>
     %endif
@@ -65,7 +64,7 @@
     </div>
 
     <%
-       options = dict(client.get_options(name))
+       options = dict(controller.get_options(name, endpoints[0]))
      %>
 
     <table class="options">
@@ -131,9 +130,9 @@
             Number of processes
             </td>
             <td class="value">
-                <a href="${url('incr_proc', name=name)}?redirect=${url('watcher', name=name)}"><span class="orangelabel">+</span></a>
+                <a href="${reverse_url('incr_proc', b64encode(endpoints[0]), name)}?redirect=${reverse_url('watcher', name)}"><span class="orangelabel">+</span></a>
                 <span class="num_process">${options['numprocesses']}</span>
-                <a href="${url('decr_proc', name=name)}?redirect=${url('watcher', name=name)}"><span class="orangelabel">-</span></a>
+                <a href="${reverse_url('decr_proc', b64encode(endpoints[0]), name)}?redirect=${reverse_url('watcher', name)}"><span class="orangelabel">-</span></a>
             </td>
         </tr>
         <tr>
@@ -154,11 +153,11 @@
         </tr>
     </table>
 
-<script src="${url('media', filename='socket.io.js')}"></script>
+<script src="${static_url('socket.io.js')}"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         var socket = io.connect('${SERVER}');
-        supervise(socket, [], ['${name}']);
+        supervise(socket, [], ['${name}'], ${dumps(endpoints)}, ${dumps(stats_endpoints)});
     });
 </script>
 

--- a/circusweb/util.py
+++ b/circusweb/util.py
@@ -1,43 +1,36 @@
-import os
 import json
 import socket
-import select
 
-from time import time
-from threading import Thread, Lock
 from urlparse import urlparse
 
-from mako.lookup import TemplateLookup
-from bottle import request, route as route_, url, redirect
+from tornado import ioloop
+from tornado import gen
+from tornado.ioloop import PeriodicCallback
 
-from circusweb import logger, __version__
-from circusweb.controller import CallError
-from circusweb.session import get_session, connect_to_circus, get_client
-
-
-def set_message(message):
-    session = get_session()
-    session['message'] = message
-    session.save()
+from circus.client import CallError
+from circusweb import logger
+from circusweb.session import get_controller
 
 
-def set_error(message):
-    return set_message("An error happened: %s" % message)
+# def set_error(message):
+#     return set_message("An error happened: %s" % message)
 
 
-def run_command(func, message, redirect_url, redirect_on_error=None,
-                args=None, kwargs=None):
+@gen.coroutine
+def run_command(command, message, endpoint, redirect_url,
+                redirect_on_error=None, args=None, kwargs=None):
 
-    func = getattr(get_client(), func)
+    command = getattr(get_controller(), command)
 
     if redirect_on_error is None:
         redirect_on_error = redirect_url
     args = args or ()
     kwargs = kwargs or {}
+    kwargs['endpoint'] = endpoint
 
     try:
-        logger.debug('Running %r' % func)
-        res = func(*args, **kwargs)
+        logger.debug('Running %r' % command)
+        res = yield gen.Task(command, *args, **kwargs)
         logger.debug('Result : %r' % res)
 
         if res['status'] != 'ok':
@@ -47,111 +40,53 @@ def run_command(func, message, redirect_url, redirect_on_error=None,
         redirect_url = redirect_on_error
 
     if message:
-        set_message(message)
-    redirect(redirect_url)
+        print message
+    #     set_message(message)
+    raise gen.Return(redirect_url)
 
 
-CURDIR = os.path.dirname(__file__)
-TMPLDIR = os.path.join(CURDIR, 'templates')
-TMPLS = TemplateLookup(directories=[TMPLDIR])
-MEDIADIR = os.path.join(CURDIR, 'media')
+class AutoDiscovery(object):
 
-
-def render_template(template, **data):
-    """Finds the given template and renders it with the given data.
-
-    Also adds some data that can be useful to the template, even if not
-    explicitely asked so.
-
-    :param template: the template to render
-    :param **data: the kwargs that will be passed when rendering the template
-    """
-    tmpl = TMPLS.get_template(template)
-    client = get_client()
-
-    # send the last message stored in the session in addition, in the "message"
-    # attribute.
-    server = '%s://%s' % (request.urlparts.scheme, request.urlparts.netloc)
-
-    return tmpl.render(client=client, version=__version__,
-                       session=get_session(), SERVER=server, **data)
-
-
-def route(*args, **kwargs):
-    """Replace the default bottle route decorator and redirect to the
-    connection page if the client is not defined
-    """
-    ensure_client = kwargs.get('ensure_client', True)
-
-    def wrapper(func):
-        def client_or_redirect(*fargs, **fkwargs):
-            if ensure_client:
-                client = get_client()
-                session = get_session()
-
-                if client is None:
-                    session = get_session()
-                    if session.get('endpoint', None) is not None:
-                        # XXX we need to pass SSH too here
-                        connect_to_circus(session['endpoint'])
-                    else:
-                        return redirect(url('connect'))
-
-            return func(*fargs, **fkwargs)
-        return route_(*args, **kwargs)(client_or_redirect)
-    return wrapper
-
-
-class AutoDiscoveryThread(Thread):
-
-    def __init__(self, multicast_endpoint, rediscover_timeout=30):
-        super(AutoDiscoveryThread, self).__init__()
+    def __init__(self, multicast_endpoint, loop, rediscover_timeout=30):
+        super(AutoDiscovery, self).__init__()
         self.multicast_endpoint = multicast_endpoint
-        self.discovered_endpoints = []
+        self.discovered_endpoints = set()
         self.rediscover_timeout = rediscover_timeout
-        self.lock = Lock()
+        self.loop = loop
 
-    def run(self):
+        self.create_socket()
+        self.callback = PeriodicCallback(self.rediscover(),
+                                         rediscover_timeout * 1000)
+
+        self.loop.add_handler(self.sock.fileno(), self.get_message,
+                              ioloop.IOLoop.READ)
+
+    def create_socket(self):
         any_addr = '0.0.0.0'
 
-        multicast_addr, multicast_port = urlparse(self.multicast_endpoint) \
-            .netloc.split(':')
-        multicast_port = int(multicast_port)
+        parsed = urlparse(self.multicast_endpoint).netloc.split(':')
+        self.multicast_addr, self.multicast_port = parsed[0], int(parsed[1])
 
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM,
-                             socket.IPPROTO_UDP)
-        sock.bind((any_addr, 0))
-        sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 255)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.setblocking(0)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM,
+                                  socket.IPPROTO_UDP)
+        self.sock.bind((any_addr, 0))
+        self.sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 255)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.setblocking(0)
 
-        sock.sendto('""', (multicast_addr, multicast_port))
+    def rediscover(self):
+        self.sock.sendto('""', (self.multicast_addr, self.multicast_port))
 
-        timer = time()
+    def get_message(self, fd_no, type):
+        data, address = self.sock.recvfrom(1024)
+        data = json.loads(data)
+        endpoint = data.get('endpoint', '')
+        if endpoint.startswith('tcp://'):
+            # In case of multi interface binding i.e:
+            # tcp://0.0.0.0:5557
+            endpoint = endpoint.replace('0.0.0.0', address[0])
 
-        while True:
-            # Wait for socket event
-            ready = select.select([sock], [], [], self.rediscover_timeout)
-
-            if ready[0]:
-                data, address = sock.recvfrom(1024)
-                data = json.loads(data)
-                endpoint = data.get('endpoint', '')
-                if endpoint.startswith('tcp://'):
-                    # In case of multi interface binding i.e:
-                    # tcp://0.0.0.0:5557
-                    endpoint = endpoint.replace('0.0.0.0', address[0])
-
-                with self.lock:
-                    self.discovered_endpoints.append(endpoint)
-
-            if time() - timer > self.rediscover_timeout * 60:
-                # Rediscover every 30 seconds
-                with self.lock:
-                    self.discovered_endpoints = []
-                timer = time()
-                sock.sendto('""', (multicast_addr, multicast_port))
+        self.discovered_endpoints.add(endpoint)
 
     def get_endpoints(self):
-        with self.lock:
-            return self.discovered_endpoints[:]
+        return list(self.discovered_endpoints)

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,11 +1,8 @@
-Mako==0.7.0
-MarkupSafe==0.15
-bottle==0.10.9
+Mako
+MarkupSafe
 anyjson
-gevent-socketio
-gevent-websocket==0.3.6
-greenlet
-beaker==1.6.3
-pyzmq==2.2.0.1
+pyzmq
 circus
-gevent
+tornado
+TornadIO2
+tomako

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,8 @@ if not hasattr(sys, 'version_info') or sys.version_info < (2, 6, 0, 'final'):
     raise SystemExit("Circus requires Python 2.6 or later.")
 
 
-install_requires = ['Mako', 'MarkupSafe', 'bottle', 'anyjson',
-                    'gevent-socketio', 'gevent-websocket', 'greenlet',
-                    'beaker', 'pyzmq', 'circus', 'gevent']
+install_requires = ['Mako', 'MarkupSafe', 'anyjson',
+                    'pyzmq', 'circus', 'tornado', 'TornadIO2', 'tomako']
 
 try:
     import argparse     # NOQA


### PR DESCRIPTION
A big refactoring of circusweb.
There is still some work we want to do but we can start the review.
- Drop gevent
- Make circus ØMQ call asynchronous
- Prepare implementation for multi-endpoint simultaneous connections (just need to update templates)
- Implement multiuser for circusweb
- Global flake8 compliancy
- Remove legacy code
