### PR TITLE
Fix missing fonts

### DIFF
--- a/circusweb/templates/base.html
+++ b/circusweb/templates/base.html
@@ -5,10 +5,10 @@
     <meta name="copyright" content="Copyright 2012, Circus Team" />
     <meta name="description" content="Control panel for the Circus Process Watcher" />
     <title>Circus Control Panel</title>
-    <!--
+
     <link href="http://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet" type="text/css">
     <link href="http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic" rel="stylesheet" type="text/css" />
-    -->
+
     <!--[if IE]>
         <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
The Ubuntu typeface is referenced in the existing template, but is commented out.  I don't have the font installed on my machine, and so things looked a little janky.  Just removed the comments block and now everything is ship-shape.

![Screenshot](http://f.cl.ly/items/440Z1k1i3v1V3E1W0v10/Screen%20Shot%202013-07-29%20at%2010.38.56%20AM.png)
