### PR TITLE
Fix draw_graph_div for display_status=True (e.g. statsd plugin).

### DIFF
--- a/circusweb/templates/index.html
+++ b/circusweb/templates/index.html
@@ -58,51 +58,51 @@
 </div>
 
 <div>
-    <%def name='draw_graph_div(watcher, name=None, display_status=False, socket=False, endpoint=None)'>
+    <%def name='draw_graph_div(watcher, name=None, display_status=False, socket=False, endpoint=None, stat_endpoint=None)'>
     <div class="process" style="margin-bottom: 15px">
         <div>
             <span style="display: inline-block; float: left;" class="label">${name or watcher}</span>
-	        <span class="age-stat" id="${watcher}-${b64encode(endpoint)}_last_age"></span>
+	        <span class="age-stat" id="${watcher}-${b64encode(stat_endpoint)}_last_age"></span>
 
             %if display_status:
-            <div style="width: 20px; float: right; margin-right: 10px;"><a class="${controller.get_status(watcher, endpoint)}" title="${controller.get_status(watcher, endpoint)}" href="${reverse_url('switch_status', endpoint, name=watcher)}"></a></div>
+            <div style="width: 20px; float: right; margin-right: 10px;"><a class="${controller.get_status(watcher, endpoint)}" title="${controller.get_status(watcher, endpoint)}" href="${reverse_url('switch_status', b64encode(stat_endpoint), watcher)}"></a></div>
             %endif
         </div>
 
         <div class="stat">
-            <div id="${watcher}-${b64encode(endpoint)}" class="graph"></div>
+            <div id="${watcher}-${b64encode(stat_endpoint)}" class="graph"></div>
             %if socket:
             <div class="metrics" >
                 <span class="metric_label">Reads</span>
-                <span class="metric_value" id="${watcher}-${b64encode(endpoint)}_last_reads">0</span>
+                <span class="metric_value" id="${watcher}-${b64encode(stat_endpoint)}_last_reads">0</span>
             </div>
             %else:
             <div class="metrics cpu">
                 <span class="metric_label">CPU</span>
-                <span class="metric_value" id="${watcher}-${b64encode(endpoint)}_last_cpu">0 %</span>
+                <span class="metric_value" id="${watcher}-${b64encode(stat_endpoint)}_last_cpu">0 %</span>
             </div>
             <div class="metrics mem">
                 <span class="metric_label">Mem</span>
-                <span class="metric_value" id="${watcher}-${b64encode(endpoint)}_last_mem">0 %</span>
+                <span class="metric_value" id="${watcher}-${b64encode(stat_endpoint)}_last_mem">0 %</span>
             </div>
             %endif
         </div>
     </div>
     </%def>
 
- ${draw_graph_div('circus', endpoint=stat_endpoint)}
- ${draw_graph_div('circusd-stats', endpoint=stat_endpoint)}
+ ${draw_graph_div('circus', endpoint=endpoint, stat_endpoint=stat_endpoint)}
+ ${draw_graph_div('circusd-stats', endpoint=endpoint, stat_endpoint=stat_endpoint)}
 
  %if controller.get_client(endpoint).embed_httpd:
- ${draw_graph_div('circushttpd', 'circushttpd', endpoint=stat_endpoint)}
+ ${draw_graph_div('circushttpd', 'circushttpd', endpoint=endpoint, stat_endpoint=stat_endpoint)}
  %endif
 
  %if controller.get_client(endpoint).use_sockets:
- ${draw_graph_div('socket-stats', 'Socket Activity (<a href="' + reverse_url('sockets', b64encode(endpoint)) + '">see all the sockets for the endpoint</a>)', socket=True, endpoint=stat_endpoint)}
+ ${draw_graph_div('socket-stats', 'Socket Activity (<a href="' + reverse_url('sockets', b64encode(endpoint)) + '">see all the sockets for the endpoint</a>)', socket=True, endpoint=endpoint, stat_endpoint=stat_endpoint)}
  %endif
 
  %for plugin in controller.get_client(endpoint).plugins:
-     ${draw_graph_div(plugin, plugin.split(':')[1].replace('-', '.'), True, endpoint=stat_endpoint)}
+     ${draw_graph_div(plugin, plugin.split(':')[1].replace('-', '.'), True, endpoint=endpoint, stat_endpoint=stat_endpoint)}
  %endfor
 
     <div style="clear:both"></div>


### PR DESCRIPTION
Stock configuration with statsd plugin enabled breaks the webconsole (empty page after connect):

```
Traceback (most recent call last):
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/circusweb/circushttpd.py", line 122, in render_template
    return template.generate(**namespace)
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/mako/template.py", line 443, in render
    return runtime._render(self, self.callable_, args, data)
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/mako/runtime.py", line 807, in _render
    **_kwargs_for_callable(callable_, data))
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/mako/runtime.py", line 839, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/mako/runtime.py", line 865, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/circusweb/templates/base.html", line 109, in render_body
    ${self.body()}
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/circusweb/templates/index.html", line 105, in render_body
    ${draw_graph_div(plugin, plugin.split(':')[1].replace('-', '.'), True, endpoint=stat_endpoint)}
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/circusweb/templates/index.html", line 1, in draw_graph_div
    <%inherit file="base.html"/>
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/circusweb/templates/index.html", line 68, in render_draw_graph_div
    <div style="width: 20px; float: right; margin-right: 10px;"><a class="${controller.get_status(watcher, endpoint)}" title="${controller.get_status(watcher, endpoint)}" href="${reverse_url('switch_status', endpoint, name=watcher)}"></a></div>
  File "/home/marcus/semantics/projects/graunt/graunt-freimann/target/lib/python2.7/site-packages/circusweb/controller.py", line 129, in get_status
    res = client.send_message('status', name=name)
AttributeError: 'NoneType' object has no attribute 'send_message'
```

Reason is that you got yourself confused about endpoint vs stat_endpoint.  It's a bit unfortunate that the outer loop uses "endpoint" for what is actually the stat_endpoint, while the controller.py get_status call use endpoint for what it is.  I cleaned up draw_graph_div, which is sufficient to make it work.  For clarity, you might want to rename endpoint in the outer loop to stat_endpoint, too.

This also fixes a small error in the reverse_url call:

```
TypeError: reverse_url() got multiple values for keyword argument 'name'
```
