### PR TITLE
Python 3 compatibility changes

### DIFF
--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 import os
 import os.path
@@ -6,8 +8,6 @@ import json
 from base64 import b64encode, b64decode
 from zmq.eventloop import ioloop
 import socket
-
-import six
 
 # Install zmq.eventloop to replace tornado.ioloop
 ioloop.install()
@@ -123,7 +123,7 @@ class BaseHandler(tornado.web.RequestHandler):
             template = app.loader.load(template_path)
             return template.generate(**namespace)
         except Exception:
-            six.print_(exceptions.text_error_template().render())
+            print(exceptions.text_error_template().render())
 
     def clean_user_session(self):
         """Disconnect the endpoint the user was logged on + Remove cookies."""

--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -7,6 +7,8 @@ from base64 import b64encode, b64decode
 from zmq.eventloop import ioloop
 import socket
 
+import six
+
 # Install zmq.eventloop to replace tornado.ioloop
 ioloop.install()
 
@@ -121,7 +123,7 @@ class BaseHandler(tornado.web.RequestHandler):
             template = app.loader.load(template_path)
             return template.generate(**namespace)
         except Exception:
-            print exceptions.text_error_template().render()
+            six.print_(exceptions.text_error_template().render())
 
     def clean_user_session(self):
         """Disconnect the endpoint the user was logged on + Remove cookies."""

--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -24,7 +24,7 @@ try:
 
     from mako import exceptions
     from tomako import MakoTemplateLoader
-except ImportError, e:
+except ImportError as e:
     reqs = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                         'web-requirements.txt')
     raise ImportError('You need to install dependencies to run the webui. '

--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -393,7 +393,7 @@ def main():
     parser.add_argument('--version', action='store_true', default=False,
                         help='Displays Circus version and exits.')
     parser.add_argument('--log-level', dest='loglevel', default='info',
-                        choices=LOG_LEVELS.keys() + [key.upper() for key in
+                        choices=list(LOG_LEVELS.keys()) + [key.upper() for key in
                                                      LOG_LEVELS.keys()],
                         help="log level")
     parser.add_argument('--log-output', dest='logoutput', default='-',

--- a/circusweb/client.py
+++ b/circusweb/client.py
@@ -85,7 +85,7 @@ class AsynchronousCircusClient(CircusClient):
 
         try:
             socket.send(cmd)
-        except zmq.ZMQError, e:
+        except zmq.ZMQError as e:
             raise CallError(str(e))
 
         if not callback:

--- a/circusweb/util.py
+++ b/circusweb/util.py
@@ -2,11 +2,7 @@ import json
 import socket
 import sys
 
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
-
+from six.moves.urllib.parse import urlparse
 from tornado import ioloop
 from tornado import gen
 from tornado.ioloop import PeriodicCallback

--- a/circusweb/util.py
+++ b/circusweb/util.py
@@ -35,7 +35,7 @@ def run_command(command, message, endpoint, redirect_url,
 
         if res['status'] != 'ok':
             message = "An error happened: %s" % res['reason']
-    except CallError, e:
+    except CallError as e:
         message = "An error happened: %s" % e
         redirect_url = redirect_on_error
 

--- a/circusweb/util.py
+++ b/circusweb/util.py
@@ -1,5 +1,6 @@
 import json
 import socket
+import sys
 
 try:
     from urlparse import urlparse
@@ -77,7 +78,12 @@ class AutoDiscovery(object):
         self.sock.setblocking(0)
 
     def rediscover(self):
-        self.sock.sendto('""', (self.multicast_addr, self.multicast_port))
+        major_python_version_number = sys.version_info[0]
+        if major_python_version_number == 3:
+            data = b'""'
+        else:
+            data = '""'
+        self.sock.sendto(data, (self.multicast_addr, self.multicast_port))
 
     def get_message(self, fd_no, type):
         data, address = self.sock.recvfrom(1024)

--- a/circusweb/util.py
+++ b/circusweb/util.py
@@ -1,7 +1,10 @@
 import json
 import socket
 
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 from tornado import ioloop
 from tornado import gen

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -4,6 +4,6 @@ anyjson
 pyzmq
 circus
 tornado
-git+git://github.com/tomassedovic/tornadio2.git@python3#tornadIO-0.0.3.1
+git+git://github.com/tomassedovic/tornadio2.git@python3#tornadIO2-0.0.3
 tomako
 six

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -4,6 +4,6 @@ anyjson
 pyzmq
 circus
 tornado
-TornadIO2
+git+git://github.com/tomassedovic/tornadio2.git@python3#tornadIO-0.0.3.1
 tomako
 six

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -6,3 +6,4 @@ circus
 tornado
 TornadIO2
 tomako
+six

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ if not hasattr(sys, 'version_info') or sys.version_info < (2, 6, 0, 'final'):
     raise SystemExit("Circus requires Python 2.6 or later.")
 
 
-install_requires = ['Mako', 'MarkupSafe', 'anyjson',
-                    'pyzmq', 'circus', 'tornado', 'TornadIO2', 'tomako']
+install_requires = ['Mako', 'MarkupSafe', 'anyjson', 'six',
+                    'pyzmq', 'circus', 'tornado', 'tornadIO2==0.0.3', 'tomako']
 
 try:
     import argparse     # NOQA
@@ -37,6 +37,9 @@ setup(name='circus-web',
           "License :: OSI Approved :: Apache Software License",
           "Development Status :: 3 - Alpha"],
       install_requires=install_requires,
+      dependency_links=[
+          'https://github.com/tomassedovic/tornadio2/archive/python3.zip#egg=tornadIO2-0.0.3',
+      ],
       tests_require=['webtest', 'unittest2'],
       test_suite='circusweb.tests',
       entry_points="""

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 -r pip-requirements.txt
 
-flake8==1.5
-unittest2==0.5.1
-WebTest==1.4.3
+flake8==2.4.1
+unittest2==1.0.1
+WebTest==2.0.18
 mock==1.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,flake8
+envlist = py26,py27,py34,flake8
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Some compatibility changes. I've seen other PR migrating from tornadIO2. I've used just a fork of it that had a PR with Py3 compatibility commits.

There are problems with tests which likely aren't compatible with newer testing libs (older aren't compatible with Py3).

`circushttpd` works and page is displayed (will have to connect to some circus still).