### PR TITLE
Correct arguments in Tornado get_arguments() usage

### DIFF
--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -161,11 +161,11 @@ class ConnectHandler(BaseHandler):
     @gen.coroutine
     def post(self):
         endpoints_list = list(self.session.endpoints)
-        endpoints = self.get_arguments('endpoint_list', [])
+        endpoints = self.get_arguments('endpoint_list')
 
         # If no selection in list
         if not endpoints:
-            endpoints = self.get_arguments('endpoint_direct', [])
+            endpoints = self.get_arguments('endpoint_direct')
 
         if not endpoints:
             self.redirect(self.reverse_url('disconnect'))


### PR DESCRIPTION
This method returns an empty list by default, and the second parameter,
'strip,' is a flag to enable stripping of the result strings.  In recent
versions of Tornado (4.2.1 here) the 'strip' parameter is checked with
an assert to ensure that its type is Bool, and this Raises in
circus-web.

Previously, the empty list [] would have evaluated Falsey, so removing
the second parameter keeps the same behavior, while fixing the call in
newer versions of Tornado.

Also see
https://github.com/circus-tent/circus-web/issues/59