### PR TITLE
removed protocol suffix to fix circus ssl insecure content warning

### DIFF
--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -15,7 +15,8 @@ from circus.exc import CallError
 from circus.util import LOG_LEVELS, configure_logger
 from zmq.eventloop import ioloop
 from circusweb.util import AutoDiscovery, run_command
-from circusweb.session import SessionManager, get_controller, connect_to_circus, disconnect_from_circus
+from circusweb.session import (SessionManager, get_controller,
+                               connect_to_circus, disconnect_from_circus)
 from circusweb.namespace import SocketIOConnection
 
 # Install zmq.eventloop to replace tornado.ioloop

--- a/circusweb/circushttpd.py
+++ b/circusweb/circushttpd.py
@@ -1,13 +1,22 @@
 from __future__ import print_function
 
-import argparse
 import os
-import os.path
 import sys
 import json
-from base64 import b64encode, b64decode
-from zmq.eventloop import ioloop
 import socket
+import os.path
+import argparse
+from uuid import uuid4
+from base64 import b64decode, b64encode
+from functools import wraps
+
+from circusweb import logger, __version__
+from circus.exc import CallError
+from circus.util import LOG_LEVELS, configure_logger
+from zmq.eventloop import ioloop
+from circusweb.util import AutoDiscovery, run_command
+from circusweb.session import SessionManager, get_controller, connect_to_circus, disconnect_from_circus
+from circusweb.namespace import SocketIOConnection
 
 # Install zmq.eventloop to replace tornado.ioloop
 ioloop.install()
@@ -32,19 +41,6 @@ except ImportError as e:
     raise ImportError('You need to install dependencies to run the webui. '
                       'You can do so by using "pip install -r '
                       '%s"\nInitial error: %s' % (reqs, str(e)))
-
-
-from circus.exc import CallError
-from circus.util import configure_logger, LOG_LEVELS
-
-from circusweb.namespace import SocketIOConnection
-from circusweb import __version__, logger
-from circusweb.util import (run_command, AutoDiscovery)
-from circusweb.session import (
-    connect_to_circus, disconnect_from_circus, get_controller, SessionManager)
-
-from uuid import uuid4
-from functools import wraps
 
 
 CURDIR = os.path.dirname(__file__)

--- a/circusweb/namespace.py
+++ b/circusweb/namespace.py
@@ -72,8 +72,8 @@ class SocketIOConnection(tornadio2.SocketConnection):
                     ['circus']
                 # these are not sockets but normal watchers
                 if watcher in available_watchers:
-                    if (watcher == 'circus'
-                            and stat.get('name', None) in available_watchers):
+                    if (watcher == 'circus' and
+                            stat.get('name', None) in available_watchers):
                         p.emit('stats-{watcher}-{endpoint}'.format(
                             watcher=stat['name'], endpoint=stat_endpoint_b64),
                             mem=stat['mem'], cpu=stat['cpu'], age=stat['age'])

--- a/circusweb/templates/base.html
+++ b/circusweb/templates/base.html
@@ -6,11 +6,11 @@
     <meta name="description" content="Control panel for the Circus Process Watcher" />
     <title>Circus Control Panel</title>
 
-    <link href="http://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic" rel="stylesheet" type="text/css" />
+    <link href="//fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic" rel="stylesheet" type="text/css" />
 
     <!--[if IE]>
-        <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+        <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <link rel="stylesheet" href="${static_url('circus.css')}" type="text/css" />
     <link rel="shortcut icon" href="${static_url('favicon.ico')}"/>


### PR DESCRIPTION
Hello,

We serve circus-web behind nginx with ssl, the google-fonts are hardcoded to use http, which causes warning in browser that some content is insecure, removing that allow the brwoser to use either http or https based access to google fonts.